### PR TITLE
ignore self instead of any other chess board spawner

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -61,12 +61,12 @@ minetest.register_node("chess:spawn",{
         for i = size, 0, -1 do
             for ii = size, 0, -1 do
                 for iii = 1, 0, -1 do
-                    if (isFree) then
+		    if (i+ii+iii~=0) then
                         
                         local p = {x=pos.x+i, y=pos.y+iii, z=pos.z+ii}
                         local n = minetest.env:get_node(p)
                         
-                        if(n.name ~= "air" and n.name ~= "chess:spawn") then
+                        if(n.name ~= "air") then
                             isFree = false
                             minetest.chat_send_all("Cannot place chess board")
                         end


### PR DESCRIPTION
![double board](http://farm9.staticflickr.com/8038/8070778648_919d0060c2_b.jpg)
`if(n.name ~= "air" and n.name ~= "chess:spawn") then` allows any chess spawner within the radius to affect board placement because it is treated as air, instead of a hindrance to placement like all other nodes are.
`if (i+ii+iii~=0) then` only ignores the start position, where the spawner that called the function should be, and uses the logic `if(n.name ~= "air") then` for everything else in the board radius, not treating chess board spawners differently than any other kind of node. 

This might not automatically merge with https://github.com/bas080/chess/pull/13, it might have to be done manually.
