### PR TITLE
Efficiently fail to place chess board.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -56,90 +56,85 @@ minetest.register_node("chess:spawn",{
     after_place_node = function(pos, placer)
         --place chess board
         
-        local isFree = true
-        
         for i = size, 0, -1 do
             for ii = size, 0, -1 do
                 for iii = 1, 0, -1 do
-		    if (i+ii+iii~=0) then
+                    if (i+ii+iii~=0) then
                         
                         local p = {x=pos.x+i, y=pos.y+iii, z=pos.z+ii}
                         local n = minetest.env:get_node(p)
                         
                         if(n.name ~= "air") then
-                            isFree = false
                             minetest.chat_send_all("Cannot place chess board")
+                            return
                         end
                     end
                 end
             end
         end
         
-        
-        if (isFree) then
-            minetest.chat_send_all("Chess board has been placed, let the match begin!")
-            for i = size, 0, -1 do
-                for ii = size, 0, -1 do
-                    --place chessboard
-                    local p = {x=pos.x+i, y=pos.y, z=pos.z+ii}
-                    local p_top = {x=pos.x+i, y=pos.y+1, z=pos.z+ii}
+        minetest.chat_send_all("Chess board has been placed, let the match begin!")
+        for i = size, 0, -1 do
+            for ii = size, 0, -1 do
+                --place chessboard
+                local p = {x=pos.x+i, y=pos.y, z=pos.z+ii}
+                local p_top = {x=pos.x+i, y=pos.y+1, z=pos.z+ii}
+                
+                if (ii == 0) or (ii == size) or (i ==0) or (i == size) then --if border
                     
-                    if (ii == 0) or (ii == size) or (i ==0) or (i == size) then --if border
-                        
-                        if (ii == 0) and (i < size) and (i > 0) then --black letters
-                            minetest.env:add_node(p, {name="chess:border_" .. letters[i]})
-                        end
-                        
-                        if (ii == size) and (i < size) and (i > 0) then --white letters
-                            minetest.env:add_node(p, {name="chess:border_" .. letters[i], param2=2})
-                        end
-                        
-                        if (i == 0) and (ii < size) and (ii > 0) then --black numbers
-                            minetest.env:add_node(p, {name="chess:border_" .. ii})
-                        end
-                        
-                        if (i == size) and (ii < size) and (ii > 0) then --white numbers
-                            minetest.env:add_node(p, {name="chess:border_" .. ii, param2=2})
-                        end
-                        
-                        if (i == 0 or i == size) and (ii == 0 or ii == size) and i+ii ~= 0 then --corners
-                            minetest.env:add_node(p, {name="chess:border"})
-                        end
-                        
-                    else--if inside border
-                        if (((ii+i)/2) == math.floor((ii+i)/2)) then
-                            minetest.env:add_node(p, {name="chess:board_black"})
-                        else
-                            minetest.env:add_node(p, {name="chess:board_white"})
-                        end
-                    end
-                    --place pieces
-                    local face = 2
-                    if (ii == 2) and (i>0) and (i<size) then --pawns
-                        minetest.env:add_node(p_top, {name="chess:pawn_white", param2 = face})
+                    if (ii == 0) and (i < size) and (i > 0) then --black letters
+                        minetest.env:add_node(p, {name="chess:border_" .. letters[i]})
                     end
                     
-                    if (ii == 1) then --behind pawns
-                        if (i == 1 or i == 8) then minetest.env:add_node(p_top, {name="chess:rook_white", param2 = face}) end
-                        if (i == 2 or i == 7) then minetest.env:add_node(p_top, {name="chess:knight_white", param2 = face}) end
-                        if (i == 3 or i == 6) then minetest.env:add_node(p_top, {name="chess:bishop_white", param2 = face}) end
-                        if (i == 4) then minetest.env:add_node(p_top, {name="chess:queen_white", param2 = face}) end
-                        if (i == 5) then minetest.env:add_node(p_top, {name="chess:king_white", param2 = face}) end
+                    if (ii == size) and (i < size) and (i > 0) then --white letters
+                        minetest.env:add_node(p, {name="chess:border_" .. letters[i], param2=2})
                     end
+                    
+                    if (i == 0) and (ii < size) and (ii > 0) then --black numbers
+                        minetest.env:add_node(p, {name="chess:border_" .. ii})
+                    end
+                    
+                    if (i == size) and (ii < size) and (ii > 0) then --white numbers
+                        minetest.env:add_node(p, {name="chess:border_" .. ii, param2=2})
+                    end
+                    
+                    if (i == 0 or i == size) and (ii == 0 or ii == size) and i+ii ~= 0 then --corners
+                        minetest.env:add_node(p, {name="chess:border"})
+                    end
+                    
+                else--if inside border
+                    if (((ii+i)/2) == math.floor((ii+i)/2)) then
+                        minetest.env:add_node(p, {name="chess:board_black"})
+                    else
+                        minetest.env:add_node(p, {name="chess:board_white"})
+                    end
+                end
+                --place pieces
+                local face = 2
+                if (ii == 2) and (i>0) and (i<size) then --pawns
+                    minetest.env:add_node(p_top, {name="chess:pawn_white", param2 = face})
+                end
+                
+                if (ii == 1) then --behind pawns
+                    if (i == 1 or i == 8) then minetest.env:add_node(p_top, {name="chess:rook_white", param2 = face}) end
+                    if (i == 2 or i == 7) then minetest.env:add_node(p_top, {name="chess:knight_white", param2 = face}) end
+                    if (i == 3 or i == 6) then minetest.env:add_node(p_top, {name="chess:bishop_white", param2 = face}) end
+                    if (i == 4) then minetest.env:add_node(p_top, {name="chess:queen_white", param2 = face}) end
+                    if (i == 5) then minetest.env:add_node(p_top, {name="chess:king_white", param2 = face}) end
+                end
 
-                    --black pieces
-                    face = 0
-                    if (ii == 7) and (i>0) and (i<size) then --pawns
-                        minetest.env:add_node(p_top, {name="chess:pawn_black", param2 = face})
-                    end
-                    
-                    if (ii == 8) then --behind pawns
-                        if (i == 1 or i == 8) then minetest.env:add_node(p_top, {name="chess:rook_black", param2 = face}) end
-                        if (i == 2 or i == 7) then minetest.env:add_node(p_top, {name="chess:knight_black", param2 = face}) end
-                        if (i == 3 or i == 6) then minetest.env:add_node(p_top, {name="chess:bishop_black", param2 = face}) end
-                        if (i == 4) then minetest.env:add_node(p_top, {name="chess:queen_black", param2 = face}) end
-                        if (i == 5) then minetest.env:add_node(p_top, {name="chess:king_black", param2 = face}) end
-                    end
+                --black pieces
+                face = 0
+                if (ii == 7) and (i>0) and (i<size) then --pawns
+                    minetest.env:add_node(p_top, {name="chess:pawn_black", param2 = face})
+                end
+                
+                if (ii == 8) then --behind pawns
+                    if (i == 1 or i == 8) then minetest.env:add_node(p_top, {name="chess:rook_black", param2 = face}) end
+                    if (i == 2 or i == 7) then minetest.env:add_node(p_top, {name="chess:knight_black", param2 = face}) end
+                    if (i == 3 or i == 6) then minetest.env:add_node(p_top, {name="chess:bishop_black", param2 = face}) end
+                    if (i == 4) then minetest.env:add_node(p_top, {name="chess:queen_black", param2 = face}) end
+                    if (i == 5) then minetest.env:add_node(p_top, {name="chess:king_black", param2 = face}) end
                 end
             end
         end


### PR DESCRIPTION
_If it fails to place the chess board:_

    **Before**, using `isFree = false`, when it printed "Cannot place chess board", it still had to make its way out of the three `for` loops and past the whole `if (isFree) then` statement all the way to the end of `after_place_node`.

    **Now**, using `return`, as soon as it prints "Cannot place chess board" it immediately exits `after_place_node`.

_If it succeeds in placing the chess board:_

    Not as much of a difference; it won't have to think about the lines `local isFree = true` and `if (isFree) then` 

(Somehow I referenced the wrong pull request or issue, and the other fix for this got closed with an unrelated issue/request; so I deleted my branch, rebranched from master, recommitted, and re-requested.)
